### PR TITLE
adding e2e tests using kuttle

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+- ./tests/e2e/
+timeout: 180

--- a/tests/e2e/crd-test/00-assert.yaml
+++ b/tests/e2e/crd-test/00-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcemanagers.resource-management.tikalk.com
+status:
+  acceptedNames:
+    plural: resourcemanagers
+    singular: resourcemanager
+    kind: ResourceManager
+    listKind: ResourceManagerList
+  storedVersions:
+    - v1alpha1

--- a/tests/e2e/create-deployment/00-assert.yaml
+++ b/tests/e2e/create-deployment/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-manager-controller-manager
+  namespace: resource-manager-system
+status:
+  readyReplicas: 1

--- a/tests/e2e/namespace-status/00-assert.yaml
+++ b/tests/e2e/namespace-status/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: resource-manager-system
+status:
+  phase: Active

--- a/tests/e2e/pod-status/00-assert.yaml
+++ b/tests/e2e/pod-status/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: resource-manager-system
+status:
+  phase: Running


### PR DESCRIPTION
Building e2e tests using Kuttl
https://kuttl.dev

The KUbernetes Test TooL (KUTTL) is a toolkit that makes it easy to test [Kubernetes Operators (opens new window)](https://kudo.dev/#what-are-operators), just using YAML.

It provides a way to inject an operator (subject under test) during the TestSuite setup and allows tests to be standard YAML files. Test assertions are often partial YAML documents which assert the state defined is true.

Then it can be added to run using Go